### PR TITLE
Feature: Automating build via Github Actions

### DIFF
--- a/.github/workflows/gradleAutomatedBuild.yml
+++ b/.github/workflows/gradleAutomatedBuild.yml
@@ -37,7 +37,13 @@ jobs:
     - name: Package Windows Executable
       run: ./gradlew run lwjgl3:packageWinX64
 
-    # Maybe add Mac build later?
+    # Has to do this since construo always output a zip, and actions/upload-artifact always zip its input
+    
+    - name: Unzip Package
+      run: unzip ./lwjgl3/build/construo/dist/*.zip -d ./lwjgl3/build/construo/dist/
+
+    - name: Remove Zipped package
+      run: rm ./lwjgl3/build/construo/dist/*.zip
 
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4
@@ -57,20 +63,19 @@ jobs:
       uses: actions/setup-java@v4
       with:
         java-version: '17'
-        # using Microsoft built OpenJDK
         distribution: 'microsoft'
-
-    # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.
-    # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
+  
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
 
-    # Construo can build cross-platform perfectly fine.
-    
-    - name: Package Windows Executable
+    - name: Package Linux Executable
       run: ./gradlew run lwjgl3:packageLinuxX64
 
-    # Maybe add Mac build later?
+    - name: Unzip Package
+      run: unzip ./lwjgl3/build/construo/dist/*.zip -d ./lwjgl3/build/construo/dist/
+
+    - name: Remove Zipped package
+      run: rm ./lwjgl3/build/construo/dist/*.zip
 
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4

--- a/.github/workflows/gradleAutomatedBuild.yml
+++ b/.github/workflows/gradleAutomatedBuild.yml
@@ -5,15 +5,15 @@
 # This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
 
-name: Java CI with Gradle
+name: Build Executable Application
 
 on:
   push:
     branches: [ "main" ]
 
 jobs:
-  build:
-
+  build-windows:
+    name: Build Windows Application
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -37,22 +37,19 @@ jobs:
     - name: Package Windows Executable
       run: ./gradlew run lwjgl3:packageWinX64
 
-    - name: Package Linux Executable
-      run: ./gradlew run lwjgl3:packageLinuxX64
-
     # Maybe add Mac build later?
 
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: Distributable Packages
+        name: Windows (x64) Executable
         path: lwjgl3/build/construo/dist
 
-  dependency-submission:
-
+  build-linux:
+    name: Build Linux Application
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
 
     steps:
     - uses: actions/checkout@v4
@@ -60,9 +57,23 @@ jobs:
       uses: actions/setup-java@v4
       with:
         java-version: '17'
+        # using Microsoft built OpenJDK
         distribution: 'microsoft'
 
-    # Generates and submits a dependency graph, enabling Dependabot Alerts for all project dependencies.
-    # See: https://github.com/gradle/actions/blob/main/dependency-submission/README.md
-    - name: Generate and submit dependency graph
-      uses: gradle/actions/dependency-submission@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+    # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.
+    # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+
+    # Construo can build cross-platform perfectly fine.
+    
+    - name: Package Windows Executable
+      run: ./gradlew run lwjgl3:packageLinuxX64
+
+    # Maybe add Mac build later?
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: Linux (x64) Executable
+        path: lwjgl3/build/construo/dist

--- a/.github/workflows/gradleAutomatedBuild.yml
+++ b/.github/workflows/gradleAutomatedBuild.yml
@@ -1,0 +1,68 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
+
+name: Java CI with Gradle
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        # using Microsoft built OpenJDK
+        distribution: 'microsoft'
+
+    # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.
+    # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+
+    # Construo can build cross-platform perfectly fine.
+    
+    - name: Package Windows Executable
+      run: ./gradlew run lwjgl3:packageWinX64
+
+    - name: Package Linux Executable
+      run: ./gradlew run lwjgl3:packageLinuxX64
+
+    # Maybe add Mac build later?
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: Distributable Packages
+        path: lwjgl3/build/construo/dist
+
+  dependency-submission:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'microsoft'
+
+    # Generates and submits a dependency graph, enabling Dependabot Alerts for all project dependencies.
+    # See: https://github.com/gradle/actions/blob/main/dependency-submission/README.md
+    - name: Generate and submit dependency graph
+      uses: gradle/actions/dependency-submission@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0

--- a/.github/workflows/gradleAutomatedBuild.yml
+++ b/.github/workflows/gradleAutomatedBuild.yml
@@ -10,6 +10,8 @@ name: Build Executable Application
 on:
   push:
     branches: [ "main" ]
+  pull_request:
+    types: [opened, reopened, synchronized]
 
 jobs:
   build-windows:


### PR DESCRIPTION
Upon a push into `main`, we will run the action. This automatically build 2 releases for Windows and Linux.

Internally this use Construo packaging system, which automatically package all assets, built file as well as the JRE into a single .jar package, and generate an executable that will allow user to run the game with a double click.