### PR TITLE
Engine Enhancement: Qt-like Signal and Slot mechanism

### DIFF
--- a/core/src/main/java/dev/kingdomino/helpers/Signal.java
+++ b/core/src/main/java/dev/kingdomino/helpers/Signal.java
@@ -1,0 +1,18 @@
+package dev.kingdomino.helpers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Signal {
+    private final List<Slot> slots = new ArrayList<Slot>();
+    
+    public void connect(Slot slot) {
+        slots.add(slot);
+    }
+
+    public void emit(Object... args) {
+        for (Slot slot : slots) {
+            slot.onSignal(args);
+        }
+    }
+}

--- a/core/src/main/java/dev/kingdomino/helpers/Slot.java
+++ b/core/src/main/java/dev/kingdomino/helpers/Slot.java
@@ -1,0 +1,6 @@
+package dev.kingdomino.helpers;
+
+@FunctionalInterface
+public interface Slot {
+    void onSignal(Object... args);
+}

--- a/core/src/main/java/dev/kingdomino/screen/AbstractRenderManager.java
+++ b/core/src/main/java/dev/kingdomino/screen/AbstractRenderManager.java
@@ -6,6 +6,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Container;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
 
 import dev.kingdomino.game.GameManager;
+import dev.kingdomino.screen.widgets.PlayerIconActor;
 
 /**
  * Defines shared implementation detail for RenderManager classes.

--- a/core/src/main/java/dev/kingdomino/screen/GameScreen.java
+++ b/core/src/main/java/dev/kingdomino/screen/GameScreen.java
@@ -24,6 +24,7 @@ import dev.kingdomino.effects.BackgroundShader;
 import dev.kingdomino.effects.CRTShader;
 import dev.kingdomino.game.GameManager;
 import dev.kingdomino.game.GameManager.GameState;
+import dev.kingdomino.screen.widgets.MainBoardActor;
 import dev.kingdomino.game.TerrainType;
 
 /**

--- a/core/src/main/java/dev/kingdomino/screen/LeaderboardRenderManager.java
+++ b/core/src/main/java/dev/kingdomino/screen/LeaderboardRenderManager.java
@@ -14,6 +14,7 @@ import com.badlogic.gdx.utils.Align;
 import dev.kingdomino.effects.actions.ShakeAnimation;
 import dev.kingdomino.game.GameManager;
 import dev.kingdomino.game.King;
+import dev.kingdomino.screen.widgets.WavyLabel;
 
 /**
  * A RenderManager specialize in handling the Leaderboard to the left of the

--- a/core/src/main/java/dev/kingdomino/screen/NextDominoRenderManager.java
+++ b/core/src/main/java/dev/kingdomino/screen/NextDominoRenderManager.java
@@ -13,6 +13,8 @@ import dev.kingdomino.game.Domino;
 import dev.kingdomino.game.DraftInputHandler;
 import dev.kingdomino.game.GameManager;
 import dev.kingdomino.game.GameManager.GameState;
+import dev.kingdomino.screen.widgets.DominoActor;
+import dev.kingdomino.screen.widgets.WavyLabel;
 import dev.kingdomino.game.King;
 import dev.kingdomino.game.Turn;
 

--- a/core/src/main/java/dev/kingdomino/screen/SidePanelManager.java
+++ b/core/src/main/java/dev/kingdomino/screen/SidePanelManager.java
@@ -11,6 +11,8 @@ import com.badlogic.gdx.utils.viewport.ScreenViewport;
 
 import dev.kingdomino.game.GameManager;
 import dev.kingdomino.game.King;
+import dev.kingdomino.screen.widgets.SideBoardActor;
+import dev.kingdomino.screen.widgets.WavyLabel;
 
 /**
  * Manage the Actors of the right-side panel of the screen.

--- a/core/src/main/java/dev/kingdomino/screen/TurnOrderRenderManager.java
+++ b/core/src/main/java/dev/kingdomino/screen/TurnOrderRenderManager.java
@@ -15,6 +15,7 @@ import com.badlogic.gdx.utils.Align;
 import dev.kingdomino.effects.actions.ShakeAnimation;
 import dev.kingdomino.game.GameManager;
 import dev.kingdomino.game.GameManager.GameState;
+import dev.kingdomino.screen.widgets.WavyLabel;
 import dev.kingdomino.game.King;
 import dev.kingdomino.game.Turn;
 

--- a/core/src/main/java/dev/kingdomino/screen/widgets/DominoActor.java
+++ b/core/src/main/java/dev/kingdomino/screen/widgets/DominoActor.java
@@ -1,4 +1,4 @@
-package dev.kingdomino.screen;
+package dev.kingdomino.screen.widgets;
 
 import static java.lang.Math.min;
 

--- a/core/src/main/java/dev/kingdomino/screen/widgets/MainBoardActor.java
+++ b/core/src/main/java/dev/kingdomino/screen/widgets/MainBoardActor.java
@@ -1,4 +1,4 @@
-package dev.kingdomino.screen;
+package dev.kingdomino.screen.widgets;
 
 import static java.lang.Math.round;
 

--- a/core/src/main/java/dev/kingdomino/screen/widgets/PlayerIconActor.java
+++ b/core/src/main/java/dev/kingdomino/screen/widgets/PlayerIconActor.java
@@ -1,4 +1,4 @@
-package dev.kingdomino.screen;
+package dev.kingdomino.screen.widgets;
 
 import static java.lang.Math.min;
 

--- a/core/src/main/java/dev/kingdomino/screen/widgets/SideBoardActor.java
+++ b/core/src/main/java/dev/kingdomino/screen/widgets/SideBoardActor.java
@@ -1,4 +1,4 @@
-package dev.kingdomino.screen;
+package dev.kingdomino.screen.widgets;
 
 import static java.lang.Math.round;
 

--- a/core/src/main/java/dev/kingdomino/screen/widgets/WavyLabel.java
+++ b/core/src/main/java/dev/kingdomino/screen/widgets/WavyLabel.java
@@ -1,4 +1,4 @@
-package dev.kingdomino.screen;
+package dev.kingdomino.screen.widgets;
 
 import java.util.Random;
 


### PR DESCRIPTION
## Motivation

Right now, the `Actors` in the UI will query the `GameManager` for update on the internal game state every, single, frame. That is something I actively disliked to do, so this PR propose to change all of that.

Now, GameManager will have a bunch of Signals that is emitted when any significant game state change, which the Actors can subscribe to via Slots, similar to the Qt Framework's Signal and Slot. Whilst not as powerful (no multi-thread communication, no type checking, no type-hinting, manual casting), it is still, in my opinion, a step forward as Actors now do not have to continuously query GameManager, but rather GameManager updating them indirectly, which should lead to performance improvement.

See [Qt Signal and Slot](https://doc.qt.io/qt-6/signalsandslots.html)

## Doesn't this increase coupling between `GameManager` and UI `Actors`?

No, as `GameManager` only job is to emit those Signal. It doesn't know who is subscribed, nor if there are even any `Actors` listening in to begin with.

## But the performance gain is minimal?

Yea, but I prefer this system, than injecting ton and ton of getter into GameManager. Should be easier to deal with. Plus we can always extend this with more feature, like cross-thread messaging.

TODO:

- [x] Implement Signal/Slot
- [ ] Testing
- [ ] Updating the codebase to utilize Signal/Slot